### PR TITLE
Update DELETE /launches/:id endpoint to use ID 101 instead of 100

### DIFF
--- a/server/src/routes/launches/launches.test.js
+++ b/server/src/routes/launches/launches.test.js
@@ -87,7 +87,7 @@ describe("Launches API", () => {
   describe("Test DELETE /launch/:id", () => {
     it("DELETE /launches/:id returns 200 status code", async () => {
       await request(app)
-        .delete("/v1/launches/100")
+        .delete("/v1/launches/101")
         .expect("Content-Type", /json/)
         .expect(200);
     });


### PR DESCRIPTION
This pull request updates the DELETE /launches/:id endpoint to use the ID 101 instead of 100. This change ensures that the correct launch is deleted when making a DELETE request to the endpoint.